### PR TITLE
Add auto-increment steps to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+      - name: 'cat package.json'
+        run: cat ./package.json
+      - name: 'Automated Version Bump'
+        id: version-bump
+        uses: 'phips28/gh-action-bump-version@master'
+        with:
+          tag-prefix: 'v'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'cat package.json'
+        run: cat ./package.json
+      - name: 'Output Step'
+        env:
+          NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
+        run: echo "new tag $NEW_TAG"
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Automatically increment the version number of the package.json so we publish a new version to NPM. 

`phips28/gh-action-bump-version` is a tool which will increment the version based on the commit message. By default it will increment patch, but if a commit contains a message like "Feature" it will increment the minor version, and for commits like "major" or "refactor" it increments the major version. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
