### PR TITLE
Fixed bucket failed to delete

### DIFF
--- a/lib/model_runner/mr_testing.ts
+++ b/lib/model_runner/mr_testing.ts
@@ -7,7 +7,7 @@ import { IVpc, SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { Stream, StreamMode } from "aws-cdk-lib/aws-kinesis";
 import { BucketAccessControl } from "aws-cdk-lib/aws-s3";
-import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
+import { BucketDeployment, Source, ServerSideEncryption } from "aws-cdk-lib/aws-s3-deployment";
 import { ITopic } from "aws-cdk-lib/aws-sns";
 import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 import { Construct } from "constructs";
@@ -130,7 +130,9 @@ export class MRTesting extends Construct {
       accessControl: BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
       memoryLimit: 10240,
       useEfs: true,
-      vpc: props.vpc
+      vpc: props.vpc,
+      retainOnDelete: props.account.prodLike,
+      serverSideEncryption: ServerSideEncryption.AES_256
     });
 
     // bucket to store rest results in

--- a/lib/osml/osml_bucket.ts
+++ b/lib/osml/osml_bucket.ts
@@ -61,7 +61,7 @@ export class OSMLBucket extends Construct {
       id,
       Object.assign(bucketProps, {
         bucketName: props.bucketName,
-        versioned: true,
+        versioned: props.prodLike,
         accessControl: BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
         serverAccessLogsBucket: this.accessLogsBucket
       })


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:**

- When destroying the test, it failed to delete the stack because the `access-logs` still have logs in it. Therefore, disabling the `versioned` property fixes the issue. The stack now be able to delete the `access-log` bucket. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
