### PR TITLE
Feature/http model endpoints

### DIFF
--- a/lib/model_runner/mr_dataplane.ts
+++ b/lib/model_runner/mr_dataplane.ts
@@ -157,7 +157,7 @@ export class MRDataplane extends Construct {
 
     // check if a role was provided
     if (props.taskRole != undefined) {
-      // import passed in MR task role
+      // import passed in an MR task role
       this.mrRole = props.taskRole;
     } else {
       // create a new role
@@ -257,26 +257,34 @@ export class MRDataplane extends Construct {
       ttlAttribute: this.mrDataplaneConfig.DDB_TTL_ATTRIBUTE
     });
 
-    // create topic for image request status notifications
+    // create a topic for image request status notifications
     this.imageStatusTopic = new OSMLTopic(this, "MRImageStatusTopic", {
       topicName: this.mrDataplaneConfig.SNS_IMAGE_STATUS_TOPIC
     });
 
-    // create topic for region request status notifications
+    // create a topic for region request status notifications
     this.regionStatusTopic = new OSMLTopic(this, "MRRegionStatusTopic", {
       topicName: this.mrDataplaneConfig.SNS_REGION_STATUS_TOPIC
     });
 
-    // create a SQS queue for the image processing jobs. This queue is subscribed to the SNS topic for new
-    // image processing tasks and will eventually filter those tasks to make sure they are destined for this
-    // processing cell. If a task fails multiple times it will be sent to a DLQ.
+    /**
+     * Create a SQS queue for the image processing jobs.
+     * This queue is subscribed to the SNS topic for new
+     * image processing tasks and will eventually filter those tasks to make
+     * sure they are destined for this processing cell.
+     * If a task fails multiple times, it will be sent to a DLQ.
+     **/
     this.imageRequestQueue = new OSMLQueue(this, "MRImageRequestQueue", {
       queueName: this.mrDataplaneConfig.SQS_IMAGE_REQUEST_QUEUE
     });
 
-    // create a SQS queue for the image region processing tasks. If an image is too large to be handled by that
-    // a single instance it will divide the image into regions and place a task for each on this queue. That allows
-    // other model runner instances to pickup part of the overall processing load for this image.
+    /**
+     * Create a SQS queue for the image region processing tasks.
+     * If an image is too large to be handled by that a single instance,
+     * it will divide the image into regions and place a task for each in this queue.
+     * That allows other model runner instances to pickup part of the overall
+     * processing load for this image.
+     **/
     this.regionRequestQueue = new OSMLQueue(this, "MRRegionRequestQueue", {
       queueName: this.mrDataplaneConfig.SQS_REGION_REQUEST_QUEUE
     });
@@ -346,7 +354,7 @@ export class MRDataplane extends Construct {
         environment: containerEnv,
         startTimeout: Duration.minutes(1),
         stopTimeout: Duration.minutes(1),
-        // create log group for console output (STDOUT)
+        // create a log group for console output (STDOUT)
         logging: new FireLensLogDriver({
           options: {
             Name: "cloudwatch",
@@ -409,7 +417,7 @@ export class MRDataplane extends Construct {
     });
 
     if (props.account.enableAutoscaling) {
-      // build service autoscaling group for MR fargate service
+      // build a service autoscaling group for MR fargate service
       this.autoScaling = new MRAutoScaling(this, "MRAutoScaling", {
         account: props.account,
         role: this.mrRole,

--- a/lib/model_runner/mr_dataplane.ts
+++ b/lib/model_runner/mr_dataplane.ts
@@ -175,6 +175,7 @@ export class MRDataplane extends Construct {
 
     // build a VPC to house containers and services
     this.osmlVpc = new OSMLVpc(this, "MRVPC", {
+      account: props.account,
       vpcName: this.mrDataplaneConfig.VPC_NAME
     });
 

--- a/lib/model_runner/mr_sm_role.ts
+++ b/lib/model_runner/mr_sm_role.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2023 Amazon.com, Inc. or its affiliates.
  */
-import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { IRole, ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
 import { OSMLAccount } from "../osml/osml_account";
@@ -14,7 +14,7 @@ export interface MRSMRoleProps {
 }
 
 export class MRSMRole extends Construct {
-  public role: Role;
+  public role: IRole;
 
   /**
    * Creates a SageMaker execution role for hosting CV models at SM endpoint.

--- a/lib/model_runner/mr_task_role.ts
+++ b/lib/model_runner/mr_task_role.ts
@@ -82,15 +82,6 @@ export class MRTaskRole extends Construct {
       })
     );
 
-    // api permissions
-    this.role.addToPolicy(
-      new PolicyStatement({
-        actions: ["oversightml:*"],
-        resources: ["*"],
-        effect: Effect.ALLOW
-      })
-    );
-
     // events permissions
     this.role.addToPolicy(
       new PolicyStatement({

--- a/lib/model_runner/mr_testing.ts
+++ b/lib/model_runner/mr_testing.ts
@@ -19,6 +19,8 @@ import { Construct } from "constructs";
 import { OSMLAccount } from "../osml/osml_account";
 import { OSMLBucket } from "../osml/osml_bucket";
 import { OSMLECRDeployment } from "../osml/osml_ecr_deployment";
+import { OSMLHTTPModelEndpoint } from "../osml/osml_http_endpoint";
+import { OSMLHTTPEndpointRole } from "../osml/osml_http_endpoint_role";
 import { OSMLQueue } from "../osml/osml_queue";
 import { OSMLSMEndpoint } from "../osml/osml_sm_endpoint";
 import { OSMLVpc } from "../osml/osml_vpc";
@@ -31,7 +33,7 @@ export class MRTestingConfig {
     // queue names
     public SQS_IMAGE_STATUS_QUEUE = "ImageStatusQueue",
     public SQS_REGION_STATUS_QUEUE = "RegionStatusQueue",
-    // sagemaker names
+    // sagemaker endpoint params
     public SM_CENTER_POINT_MODEL = "centerpoint",
     public SM_FLOOD_MODEL = "flood",
     public SM_AIRCRAFT_MODEL = "aircraft",
@@ -41,11 +43,21 @@ export class MRTestingConfig {
     public SM_VARIANT_NAME = "AllTraffic",
     public SM_CPU_INSTANCE_TYPE = "ml.m5.xlarge",
     public SM_GPU_INSTANCE_TYPE = "ml.p3.2xlarge",
+    // http endpoint params
+    public HTTP_ENDPOINT_NAME = "HTTPModelCluster",
+    public HTTP_ENDPOINT_ROLE_NAME = "HTTPEndpointRole",
+    public HTTP_ENDPOINT_HOST_PORT = 8080,
+    public HTTP_ENDPOINT_CONTAINER_PORT = 8080,
+    public HTTP_ENDPOINT_MEMORY = 16384,
+    public HTTP_ENDPOINT_CPU = 4096,
+    public HTTP_ENDPOINT_HEALTHCHECK_PATH = "/ping",
+    public HTTP_ENDPOINT_DOMAIN_NAME = "test-http-model-endpoint",
     // bucket names
     public S3_RESULTS_BUCKET = "test-results",
     public S3_IMAGE_BUCKET = "test-images",
     // path to test images
     public S3_TEST_IMAGES_PATH = "assets/images",
+    // default model container to pull from
     public MODEL_DEFAULT_CONTAINER = "awsosml/osml-models:main",
     // ecr repo names
     public ECR_MODEL_REPOSITORY = "model-container",
@@ -66,6 +78,8 @@ export interface MRTestingProps {
   imageStatusTopic: ITopic;
   // the model runner region status topic
   regionStatusTopic: ITopic;
+  // role to apply to the http endpoint fargate tasks
+  httpEndpointRole?: IRole;
   // optional custom configuration for the testing resources - will be defaulted if not provided
   mrTestingConfig?: MRTestingConfig;
   // optional sage maker iam role to use for endpoint construction - will be defaulted if not provided
@@ -77,6 +91,7 @@ export interface MRTestingProps {
   deployCenterpointModel?: boolean;
   deployFloodModel?: boolean;
   deployAircraftModel?: boolean;
+  deployHttpCenterpointModel?: boolean;
 }
 
 export class MRTesting extends Construct {
@@ -90,6 +105,8 @@ export class MRTesting extends Construct {
   public removalPolicy: RemovalPolicy;
   public mrTestingConfig: MRTestingConfig;
   public smRole?: IRole;
+  public httpEndpointRole?: IRole;
+  public httpCenterpointModelEndpoint?: OSMLHTTPModelEndpoint;
   public centerPointModelEndpoint?: OSMLSMEndpoint;
   public floodModelEndpoint?: OSMLSMEndpoint;
   public aircraftModelEndpoint?: OSMLSMEndpoint;
@@ -153,7 +170,7 @@ export class MRTesting extends Construct {
 
     // check if a role was provided
     if (props.smRole != undefined) {
-      // import passed in MR task role
+      // import custom SageMaker endpoint role
       this.smRole = props.smRole;
     } else {
       // create a new role
@@ -164,6 +181,7 @@ export class MRTesting extends Construct {
     }
 
     if (
+      props.deployHttpCenterpointModel != false ||
       props.deployCenterpointModel != false ||
       props.deployAircraftModel != false ||
       props.deployFloodModel != false
@@ -190,6 +208,49 @@ export class MRTesting extends Construct {
         }
       );
     }
+    if (props.deployHttpCenterpointModel != false) {
+      // check if a role was provided
+      if (props.httpEndpointRole != undefined) {
+        // import passed custom role for the httpEndpoint
+        this.httpEndpointRole = props.httpEndpointRole;
+      } else {
+        // create a new role
+        this.httpEndpointRole = new OSMLHTTPEndpointRole(
+          this,
+          "HTTPEndpointTaskRole",
+          {
+            account: props.account,
+            roleName: this.mrTestingConfig.HTTP_ENDPOINT_ROLE_NAME
+          }
+        ).role;
+      }
+
+      // build a Fargate HTTP endpoint from the centerpoint model container
+      this.httpCenterpointModelEndpoint = new OSMLHTTPModelEndpoint(
+        this,
+        "OSMLHTTPCenterPointModelEndpoint",
+        {
+          account: props.account,
+          vpc: props.osmlVpc.vpc,
+          image: this.modelContainerEcrDeployment.containerImage,
+          clusterName: this.mrTestingConfig.HTTP_ENDPOINT_NAME,
+          role: this.httpEndpointRole,
+          memory: this.mrTestingConfig.HTTP_ENDPOINT_MEMORY,
+          cpu: this.mrTestingConfig.HTTP_ENDPOINT_CPU,
+          hostPort: this.mrTestingConfig.HTTP_ENDPOINT_HOST_PORT,
+          containerPort: this.mrTestingConfig.HTTP_ENDPOINT_CONTAINER_PORT,
+          healthcheckPath: this.mrTestingConfig.HTTP_ENDPOINT_HEALTHCHECK_PATH,
+          loadBalancerName: this.mrTestingConfig.HTTP_ENDPOINT_DOMAIN_NAME,
+          containerEnv: {
+            MODEL_SELECTION: this.mrTestingConfig.SM_CENTER_POINT_MODEL
+          }
+        }
+      );
+      this.httpCenterpointModelEndpoint.node.addDependency(
+        this.modelContainerEcrDeployment
+      );
+    }
+
     if (props.deployCenterpointModel != false) {
       // build an SM endpoint from the centerpoint model container
       this.centerPointModelEndpoint = new OSMLSMEndpoint(

--- a/lib/model_runner/mr_testing.ts
+++ b/lib/model_runner/mr_testing.ts
@@ -231,7 +231,7 @@ export class MRTesting extends Construct {
         "OSMLHTTPCenterPointModelEndpoint",
         {
           account: props.account,
-          vpc: props.osmlVpc.vpc,
+          osmlVpc: props.osmlVpc,
           image: this.modelContainerEcrDeployment.containerImage,
           clusterName: this.mrTestingConfig.HTTP_ENDPOINT_NAME,
           role: this.httpEndpointRole,

--- a/lib/osml/osml_http_endpoint.ts
+++ b/lib/osml/osml_http_endpoint.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ */
+
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import { IVpc } from "aws-cdk-lib/aws-ec2";
+import {
+  Cluster,
+  Compatibility,
+  ContainerImage, LogDriver, Protocol,
+  TaskDefinition
+} from "aws-cdk-lib/aws-ecs";
+import { ApplicationLoadBalancedFargateService } from "aws-cdk-lib/aws-ecs-patterns";
+import { IRole } from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+import { OSMLAccount } from "./osml_account";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+export interface OSMLHTTPEndpointProps {
+  account: OSMLAccount;
+  vpc: IVpc;
+  image: ContainerImage;
+  clusterName: string;
+  role: IRole;
+  memory: number;
+  cpu: number;
+  hostPort: number;
+  containerPort: number;
+  healthcheckPath: string;
+  loadBalancerName: string;
+  containerEnv?: {};
+}
+
+export class OSMLHTTPModelEndpoint extends Construct {
+  public networkHTTPEndpoint: ApplicationLoadBalancedFargateService;
+  public logGroup: LogGroup;
+  public removalPolicy: RemovalPolicy;
+  constructor(scope: Construct, id: string, props: OSMLHTTPEndpointProps) {
+    super(scope, id);
+    const httpEndpointCluster = new Cluster(this, props.clusterName, {
+      clusterName: props.clusterName,
+      vpc: props.vpc
+    });
+    // setup a removal policy
+    this.removalPolicy = props.account.prodLike
+      ? RemovalPolicy.RETAIN
+      : RemovalPolicy.DESTROY;
+
+    // log group for MR container
+    this.logGroup = new LogGroup(this, "MRServiceLogGroup", {
+      logGroupName: "/aws/OSML/HTTPEndpoint",
+      retention: RetentionDays.TEN_YEARS,
+      removalPolicy: this.removalPolicy
+    });
+
+    const taskDefinition = new TaskDefinition(
+      this,
+      "HTTPEndpointFargateTaskDefinition",
+      {
+        memoryMiB: props.memory.toString(),
+        cpu: props.cpu.toString(),
+        compatibility: Compatibility.FARGATE,
+        taskRole: props.role,
+        ephemeralStorageGiB: 100
+      }
+    );
+    taskDefinition.addContainer("HTTPEndpointContainer", {
+      image: props.image,
+      portMappings: [
+        {
+          containerPort: props.containerPort,
+          hostPort: props.hostPort,
+          protocol: Protocol.TCP,
+        }
+      ],
+      logging: LogDriver.awsLogs({
+        logGroup: this.logGroup,
+        streamPrefix: "OSML"
+      }),
+      environment: props.containerEnv
+    });
+
+    this.networkHTTPEndpoint = new ApplicationLoadBalancedFargateService(
+      this,
+      `${id}-HTTPEndpointService`,
+      {
+        cluster: httpEndpointCluster,
+        loadBalancerName: props.loadBalancerName,
+        healthCheckGracePeriod: Duration.seconds(120),
+        taskDefinition: taskDefinition
+      }
+    );
+
+    this.networkHTTPEndpoint.targetGroup.configureHealthCheck({
+      path: props.healthcheckPath,
+      port: props.hostPort.toString()
+    });
+  }
+}

--- a/lib/osml/osml_http_endpoint_role.ts
+++ b/lib/osml/osml_http_endpoint_role.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ */
+import { region_info } from "aws-cdk-lib";
+import {
+  CompositePrincipal,
+  ManagedPolicy,
+  Role,
+  ServicePrincipal
+} from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+
+import { OSMLAccount } from "./osml_account";
+
+export interface MRTaskRoleProps {
+  // the osml account interface
+  account: OSMLAccount;
+  // the name to give the role
+  roleName: string;
+}
+
+export class OSMLHTTPEndpointRole extends Construct {
+  public role: Role;
+  public partition: string;
+
+  /**
+   * Creates an OSMLHTTPEndpointRole construct.
+   * @param scope the scope/stack in which to define this construct.
+   * @param id the id of this construct within the current scope.
+   * @param props the properties of this construct.
+   * @returns the MRTaskRole construct.
+   */
+  constructor(scope: Construct, id: string, props: MRTaskRoleProps) {
+    super(scope, id);
+    this.partition = region_info.Fact.find(
+      props.account.region,
+      region_info.FactName.PARTITION
+    )!;
+
+    // model runner Fargate ECS task role
+    this.role = new Role(this, "OSMLHTTPEndpointRole", {
+      roleName: props.roleName,
+      assumedBy: new CompositePrincipal(
+        new ServicePrincipal("ecs-tasks.amazonaws.com"),
+        new ServicePrincipal("lambda.amazonaws.com")
+      ),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName("CloudWatchFullAccess"),
+        ManagedPolicy.fromAwsManagedPolicyName(
+          "AmazonElasticContainerRegistryPublicFullAccess"
+        ),
+        ManagedPolicy.fromAwsManagedPolicyName("CloudWatchFullAccess"),
+      ],
+      description:
+        "Allows the OversightML HTTP model endpoint to access necessary resources."
+    });
+  }
+}

--- a/lib/osml/osml_sm_endpoint.ts
+++ b/lib/osml/osml_sm_endpoint.ts
@@ -61,7 +61,7 @@ export class OSMLSMEndpoint extends Construct {
         }
       ],
       vpcConfig: {
-        subnets: props.osmlVpc.selectedSubnets.subnetIds,
+        subnets: props.osmlVpc.privateSubnets.subnetIds,
         securityGroupIds: [props.osmlVpc.vpcDefaultSecurityGroup]
       }
     });

--- a/lib/osml/osml_vpc.ts
+++ b/lib/osml/osml_vpc.ts
@@ -4,7 +4,11 @@
 import { IVpc, SelectedSubnets, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 
+import { OSMLAccount } from "./osml_account";
+
 export interface OSMLVpcProps {
+  // the osml deployment account
+  account: OSMLAccount;
   // name of the VPC to create
   vpcName?: string;
   // the vpc id to import
@@ -14,10 +18,10 @@ export interface OSMLVpcProps {
 export class OSMLVpc extends Construct {
   public readonly vpc: IVpc;
   public readonly vpcDefaultSecurityGroup: string;
-  public readonly selectedSubnets: SelectedSubnets;
+  public readonly privateSubnets: SelectedSubnets;
 
   /**
-   * Creates or imports a VPC for OSML.
+   * Creates or imports a VPC for OSML to operate in.
    * @param scope the scope/stack in which to define this construct.
    * @param id the id of this construct within the current scope.
    * @param props the properties of this construct.
@@ -25,7 +29,7 @@ export class OSMLVpc extends Construct {
    */
   constructor(scope: Construct, id: string, props: OSMLVpcProps) {
     super(scope, id);
-    // if a osmlVpc id is not explicitly given use the default osmlVpc
+    // if an vpcId id is not explicitly given, build the default osmlVpc
     if (props.vpcId) {
       this.vpc = Vpc.fromLookup(this, "OSMLImportVPC", {
         vpcId: props.vpcId,
@@ -48,8 +52,12 @@ export class OSMLVpc extends Construct {
         ]
       });
       this.vpc = vpc;
+
+      // expose the default security group created with the VPC
       this.vpcDefaultSecurityGroup = vpc.vpcDefaultSecurityGroup;
-      this.selectedSubnets = vpc.selectSubnets({
+
+      // expose the private subnets associated with the VPC
+      this.privateSubnets = vpc.selectSubnets({
         subnetType: SubnetType.PRIVATE_WITH_EGRESS
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.48.2",
         "aws-cdk": "^2.85.0",
-        "aws-cdk-lib": "^2.85.0",
+        "aws-cdk-lib": "^2.87.0",
         "cdk-ecr-deployment": "^2.5.30",
         "cdk-nag": "^2.27.48",
         "constructs": "^10.2.57",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.48.2",
     "aws-cdk": "^2.85.0",
-    "aws-cdk-lib": "^2.85.0",
+    "aws-cdk-lib": "^2.87.0",
     "cdk-ecr-deployment": "^2.5.30",
     "cdk-nag": "^2.27.48",
     "constructs": "^10.2.57",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding support for the deployment of an HTTP model deployed onto a Fargate cluster to host said model. Allows for the testing of non-SageMaker endpoints within osml-model-runner. 

Built and deployed these changes through the guidance package. Ensured that the model started succesfully big checking startup logs on the cluster:
```
INFO     : Initializing REST Model Server...
INFO     : Argument command: 'serve'
INFO     : Argument verbose: False
INFO     : Serving on http://0.0.0.0:8080
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
