### PR TITLE
hotfix: fix sg/modelUri passthrough

### DIFF
--- a/lib/model_runner/mr_dataplane.ts
+++ b/lib/model_runner/mr_dataplane.ts
@@ -95,7 +95,7 @@ export interface MRDataplaneProps {
   // enable autoscaling for the fargate service
   enableAutoscaling?: boolean;
   // custom autoscaling configuration
-  mrAutoscalingConfig: MRAutoscalingConfig
+  mrAutoscalingConfig?: MRAutoscalingConfig
   // subnets to deploy infrastructure into
   targetSubnets?: string[];
 }

--- a/lib/model_runner/mr_dataplane.ts
+++ b/lib/model_runner/mr_dataplane.ts
@@ -33,7 +33,7 @@ import { OSMLQueue } from "../osml/osml_queue";
 import { OSMLTable } from "../osml/osml_table";
 import { OSMLTopic } from "../osml/osml_topic";
 import { OSMLVpc } from "../osml/osml_vpc";
-import { MRAutoScaling } from "./mr_autoscaling";
+import { MRAutoScaling, MRAutoscalingConfig } from "./mr_autoscaling";
 import { MRTaskRole } from "./mr_task_role";
 
 // mutable configuration dataclass for model runner
@@ -94,6 +94,8 @@ export interface MRDataplaneProps {
   dataplaneConfig?: MRDataplaneConfig;
   // enable autoscaling for the fargate service
   enableAutoscaling?: boolean;
+  // custom autoscaling configuration
+  mrAutoscalingConfig: MRAutoscalingConfig
   // subnets to deploy infrastructure into
   targetSubnets?: string[];
 }
@@ -447,7 +449,8 @@ export class MRDataplane extends Construct {
         regionRequestQueue: this.regionRequestQueue.queue,
         cluster: this.cluster,
         service: this.fargateService,
-        mrDataplaneConfig: this.mrDataplaneConfig
+        mrDataplaneConfig: this.mrDataplaneConfig,
+        mrAutoscalingConfig: props.mrAutoscalingConfig
       });
     }
   }

--- a/lib/model_runner/mr_testing.ts
+++ b/lib/model_runner/mr_testing.ts
@@ -212,7 +212,7 @@ export class MRTesting extends Construct {
         this,
         "OSMLModelContainer",
         {
-          sourceUri: this.mrTestingConfig.MODEL_DEFAULT_CONTAINER,
+          sourceUri: this.modelContainerSourceUri,
           repositoryName: this.mrTestingConfig.ECR_MODEL_REPOSITORY,
           removalPolicy: this.removalPolicy,
           osmlVpc: props.osmlVpc

--- a/lib/model_runner/mr_testing.ts
+++ b/lib/model_runner/mr_testing.ts
@@ -2,8 +2,7 @@
  * Copyright 2023 Amazon.com, Inc. or its affiliates.
  */
 
-import { RemovalPolicy, SymlinkFollowMode } from "aws-cdk-lib";
-import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
+import { RemovalPolicy, Size, SymlinkFollowMode } from "aws-cdk-lib";
 import { DockerImageAsset } from "aws-cdk-lib/aws-ecr-assets";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { Stream, StreamMode } from "aws-cdk-lib/aws-kinesis";
@@ -152,8 +151,9 @@ export class MRTesting extends Construct {
       destinationBucket: this.imageBucket.bucket,
       accessControl: BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
       memoryLimit: 10240,
-      useEfs: true,
+      ephemeralStorageSize: Size.mebibytes(8196),
       vpc: props.osmlVpc.vpc,
+      vpcSubnets: props.osmlVpc.selectedSubnets,
       retainOnDelete: props.account.prodLike,
       serverSideEncryption: ServerSideEncryption.AES_256
     });
@@ -254,7 +254,8 @@ export class MRTesting extends Construct {
           loadBalancerName: this.mrTestingConfig.HTTP_ENDPOINT_DOMAIN_NAME,
           containerEnv: {
             MODEL_SELECTION: this.mrTestingConfig.SM_CENTER_POINT_MODEL
-          }
+          },
+          securityGroupId: this.securityGroupId
         }
       );
       this.httpCenterpointModelEndpoint.node.addDependency(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the passing in of the correct security groups to sub components of the testing resources deployment. Adding private subnets to addition testing resources where they should be specified. Moving to using ephemeral storage for bucket deployment lambda since efs isn't enabled for all customers.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
