### PR TITLE
fix: endpoint ecr dependancy

### DIFF
--- a/lib/osml/model_runner/testing/mr_model_endpoints.ts
+++ b/lib/osml/model_runner/testing/mr_model_endpoints.ts
@@ -147,7 +147,7 @@ export class MREndpoints extends Construct {
 
         this.modelContainerUri = dockerImageAsset.imageUri;
       } else {
-        const osmlEcrDeployment = new OSMLECRDeployment(
+        this.modelContainerEcrDeployment = new OSMLECRDeployment(
           this,
           "OSMLModelContainer",
           {
@@ -158,8 +158,10 @@ export class MREndpoints extends Construct {
             vpcSubnets: props.osmlVpc.selectedSubnets
           }
         );
-        this.modelContainerImage = osmlEcrDeployment.containerImage;
-        this.modelContainerUri = osmlEcrDeployment.ecrContainerUri;
+        this.modelContainerImage =
+          this.modelContainerEcrDeployment.containerImage;
+        this.modelContainerUri =
+          this.modelContainerEcrDeployment.ecrContainerUri;
       }
     }
     if (props.deployHttpCenterpointModel != false) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating such that the ECR repositories that are created when isDev is false are properly depended on by the Endpoints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
