### PR TITLE
fix: Update `needs` condition for Notify workflow

### DIFF
--- a/.github/workflows/osml-cdk-constructs-publish.yml
+++ b/.github/workflows/osml-cdk-constructs-publish.yml
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/npm-publish.yml
     secrets: inherit
   Notify_Guidance_Repo:
-    needs: [Publish_NPM]
+    needs: [Build_NPM]
     uses: ./.github/workflows/notify-guidance-repo.yml
     secrets: inherit


### PR DESCRIPTION
*Issue #, if available:*

**Description of changes:**
- This workflow only works if merged in main branch. I need to update this workflow such that it should notify the guidance repo if merged into dev branch as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
