### PR TITLE
fix: Update partition key for tileserver table

### DIFF
--- a/lib/osml/tile_server/ts_dataplane.ts
+++ b/lib/osml/tile_server/ts_dataplane.ts
@@ -165,7 +165,7 @@ export class TSDataplane extends Construct {
     this.jobTable = new OSMLTable(this, "TSJobTable", {
       tableName: this.config.DDB_JOB_TABLE,
       partitionKey: {
-        name: "request_id",
+        name: "viewpoint_id",
         type: AttributeType.STRING
       },
       removalPolicy: this.removalPolicy,


### PR DESCRIPTION
*Issue #, if available:* n/a

**Description of changes:**
- Update the partition key for tile server table since Tile Server repo relies on `viewpoint_id` as a partition name 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
