### PR TITLE
adding ephemeral storage parameter to tile server task definition

### DIFF
--- a/lib/osml/tile_server/ts_dataplane.ts
+++ b/lib/osml/tile_server/ts_dataplane.ts
@@ -284,6 +284,7 @@ export class TSDataplane extends Construct {
       cpu: this.config.ECS_TASK_CPU.toString(),
       compatibility: Compatibility.FARGATE,
       taskRole: this.taskRole,
+      ephemeralStorageGiB: 21,
       volumes: [
         {
           name: this.config.EFS_MOUNT_NAME,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the ephemeralStorage parameter to the Tile Server task definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
