### PR TITLE
feat: implementing tile server health check for ECS tasks

### DIFF
--- a/lib/osml/tile_server/ts_dataplane.ts
+++ b/lib/osml/tile_server/ts_dataplane.ts
@@ -315,7 +315,13 @@ export class TSDataplane extends Construct {
           logGroup: this.logGroup,
           mode: AwsLogDriverMode.NON_BLOCKING
         }),
-        disableNetworking: false
+        disableNetworking: false,
+        healthCheck: {
+          command: ["curl --fail http://localhost:8080/ping || exit 1"],
+          interval: Duration.seconds(10),
+          retries: 3,
+          timeout: Duration.seconds(10)
+        }
       }
     );
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implementing tile server health check for ECS tasks. Deployed and tested in dev account to verify healthy status checks out on the ECS tasks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
