### PR TITLE
fix: upgrading cdk-ecr-deployment to remove unsupported AWS Lambda go…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/parser": "^5.62.0",
         "aws-cdk": "^2.104.0",
         "aws-cdk-lib": "^2.104.0",
-        "cdk-ecr-deployment": "^2.5.30",
+        "cdk-ecr-deployment": "^3.0.28",
         "cdk-nag": "^2.27.178",
         "constructs": "^10.3.0",
         "eslint": "^8.52.0",
@@ -2917,9 +2917,9 @@
       ]
     },
     "node_modules/cdk-ecr-deployment": {
-      "version": "2.5.41",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
-      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.34.tgz",
+      "integrity": "sha512-AeZ1B4bTXqHqYBuKZV5bOy3MlbY6OurbI4+krBLtdUcsio7t/AsjpJ4lS+ZFv4BCFwpvkaz8jImuVq5ip44+OQ==",
       "bundleDependencies": [
         "got",
         "hpagent"
@@ -2973,7 +2973,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/cacheable-request/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.11.26",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2997,7 +2997,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/keyv/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.11.26",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3015,7 +3015,7 @@
       }
     },
     "node_modules/cdk-ecr-deployment/node_modules/@types/responselike/node_modules/@types/node": {
-      "version": "20.10.4",
+      "version": "20.11.26",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9960,9 +9960,9 @@
       "dev": true
     },
     "cdk-ecr-deployment": {
-      "version": "2.5.41",
-      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-2.5.41.tgz",
-      "integrity": "sha512-eOnoWJ3h/PrSVjmC1QzmfK2DyvT6xBBy3ER0MeZmqTvrI+ZkOKY2ZDwNxdE2bMHmQy5XB0pAxnOVEc+FlpQSsg==",
+      "version": "3.0.34",
+      "resolved": "https://registry.npmjs.org/cdk-ecr-deployment/-/cdk-ecr-deployment-3.0.34.tgz",
+      "integrity": "sha512-AeZ1B4bTXqHqYBuKZV5bOy3MlbY6OurbI4+krBLtdUcsio7t/AsjpJ4lS+ZFv4BCFwpvkaz8jImuVq5ip44+OQ==",
       "dev": true,
       "requires": {
         "aws-cdk-lib": "^2.0.0",
@@ -9996,7 +9996,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.11.26",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -10019,7 +10019,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.11.26",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -10037,7 +10037,7 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "20.10.4",
+              "version": "20.11.26",
               "bundled": true,
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "aws-cdk": "^2.104.0",
     "aws-cdk-lib": "^2.104.0",
     "cdk-nag": "^2.27.178",
-    "cdk-ecr-deployment": "^2.5.30",
+    "cdk-ecr-deployment": "^3.0.28",
     "constructs": "^10.3.0",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^8.10.0",


### PR DESCRIPTION
… runtime

*Issue #, if available:*

*Description of changes:*
upgrading cdk-ecr-deployment to remove unsupported AWS Lambda go runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
