### PR TITLE
fix: adding dependency between tile server test lambda and ecr repo

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,5 +27,6 @@ export * from "./osml/osml_vpc";
 export * from "./osml/tile_server/ts_container";
 export * from "./osml/tile_server/ts_dataplane";
 export * from "./osml/tile_server/roles/ts_task_role";
+export * from "./osml/tile_server/testing/ts_test_runner_container";
 export * from "./osml/tile_server/testing/ts_test_runner";
 export * from "./osml/tile_server/testing/ts_imagery";

--- a/lib/osml/tile_server/testing/ts_test_runner.ts
+++ b/lib/osml/tile_server/testing/ts_test_runner.ts
@@ -2,33 +2,13 @@
  * Copyright 2024 Amazon.com, Inc. or its affiliates.
  */
 
-import { Duration, RemovalPolicy, SymlinkFollowMode } from "aws-cdk-lib";
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { DockerImageCode, DockerImageFunction } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 
 import { OSMLAccount } from "../../osml_account";
-import { OSMLECRDeployment } from "../../osml_ecr_deployment";
 import { OSMLVpc } from "../../osml_vpc";
-
-/**
- * Represents the configuration for the TSTestContainer Construct.
- */
-export class TSTestRunnerConfig {
-  /**
-   * Creates an instance of TSContainerConfig.
-   * @param {string} [TS_TEST_CONTAINER="awsosml/osml-tile-server-test:main"] - The container image to use for the TileServer test.
-   * @param {string} [TS_TEST_BUILD_PATH="lib/osml-tile-server-test"] - The build path for the TileServer test.
-   * @param {string} [TS_TEST_BUILD_TARGET="osml_tile_sever_test"] - The build target for the TileServer test.
-   * @param {string} [TS_TEST_REPOSITORY="tile-server-test-container"] - The repository name for the TileServer test.
-   */
-  constructor(
-    public TS_TEST_CONTAINER: string = "awsosml/osml-tile-server-test:main",
-    public TS_TEST_BUILD_PATH: string = "lib/osml-tile-server-test",
-    public TS_TEST_BUILD_TARGET: string = "osml_tile_server_test",
-    public TS_TEST_REPOSITORY: string = "tile-server-test-container"
-  ) {}
-}
 
 /**
  * Interface representing the properties for the TSTestRunner construct.
@@ -45,29 +25,14 @@ export interface TSTestRunnerProps {
   osmlVpc: OSMLVpc;
 
   /**
-   * The DNS name of the Tile Server load balancer endpoint
+   * The Docker image code to use for the lambda function
    */
-  tsEndpoint: string;
-
-  /**
-   * The S3 bucket name that contains test images for Tile Server
-   */
-  tsTestImageBucket: string;
+  dockerImageCode: DockerImageCode;
 
   /**
    * Optional task role to be used by the TSTestContainer.
    */
   taskRole?: IRole;
-
-  /**
-   * Optional flag to instruct building tile server test container from source.
-   */
-  buildFromSource?: boolean;
-
-  /**
-   * Optional configuration for the TSTestContainer Construct
-   */
-  config?: TSTestRunnerConfig;
 }
 
 /**
@@ -76,7 +41,6 @@ export interface TSTestRunnerProps {
  */
 export class TSTestRunner extends Construct {
   public removalPolicy: RemovalPolicy;
-  public config: TSTestRunnerConfig;
   public lambdaIntegRunner: DockerImageFunction;
   /**
    * Creates an instance of TSTestRunner.
@@ -93,57 +57,8 @@ export class TSTestRunner extends Construct {
       ? RemovalPolicy.RETAIN
       : RemovalPolicy.DESTROY;
 
-    // Check if a custom configuration was provided: otherwise, create a new default configuration.
-    if (props.config != undefined) {
-      // Import the existing TSTest configuration
-      this.config = props.config;
-    } else {
-      // Create a new default configuration
-      this.config = new TSTestRunnerConfig();
-    }
-
-    let dockerImageCode: DockerImageCode | undefined = undefined;
-    const testEntrypoint: string[] = [
-      "python",
-      "src/aws/osml/run_test.py",
-      "--endpoint",
-      props.tsEndpoint,
-      "--source_image_bucket",
-      props.tsTestImageBucket,
-      "-v"
-    ];
-
-    if (props.buildFromSource == true) {
-      // Create a container image from a Docker image asset for development environment.
-      dockerImageCode = DockerImageCode.fromImageAsset(
-        this.config.TS_TEST_BUILD_PATH,
-        {
-          file: "Dockerfile",
-          followSymlinks: SymlinkFollowMode.ALWAYS,
-          target: this.config.TS_TEST_BUILD_TARGET,
-          entrypoint: testEntrypoint
-        }
-      );
-    } else {
-      // Create an ECR deployment for production environment.
-      const ecrDeployment: OSMLECRDeployment = new OSMLECRDeployment(
-        this,
-        "TSTestContainerECRDeployment",
-        {
-          account: props.account,
-          sourceUri: this.config.TS_TEST_CONTAINER,
-          repositoryName: this.config.TS_TEST_REPOSITORY,
-          removalPolicy: this.removalPolicy,
-          vpc: props.osmlVpc.vpc,
-          vpcSubnets: props.osmlVpc.selectedSubnets
-        }
-      );
-      dockerImageCode = DockerImageCode.fromEcr(ecrDeployment.ecrRepository, {
-        entrypoint: testEntrypoint
-      });
-    }
     this.lambdaIntegRunner = new DockerImageFunction(this, "TSTestRunner", {
-      code: dockerImageCode,
+      code: props.dockerImageCode,
       vpc: props.osmlVpc.vpc,
       role: props.taskRole,
       timeout: Duration.minutes(10),

--- a/lib/osml/tile_server/testing/ts_test_runner_container.ts
+++ b/lib/osml/tile_server/testing/ts_test_runner_container.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates.
+ */
+
+import { RemovalPolicy, SymlinkFollowMode } from "aws-cdk-lib";
+import { IRole } from "aws-cdk-lib/aws-iam";
+import { DockerImageCode } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+import { OSMLAccount } from "../../osml_account";
+import { OSMLECRDeployment } from "../../osml_ecr_deployment";
+import { OSMLVpc } from "../../osml_vpc";
+
+/**
+ * Represents the configuration for the TSTestContainer Construct.
+ */
+export class TSTestRunnerContainerConfig {
+  /**
+   * Creates an instance of TSContainerConfig.
+   * @param {string} [TS_TEST_CONTAINER="awsosml/osml-tile-server-test:latest"] - The container image to use for the TileServer test.
+   * @param {string} [TS_TEST_BUILD_PATH="lib/osml-tile-server-test"] - The build path for the TileServer test.
+   * @param {string} [TS_TEST_BUILD_TARGET="osml_tile_sever_test"] - The build target for the TileServer test.
+   * @param {string} [TS_TEST_REPOSITORY="tile-server-test-container"] - The repository name for the TileServer test.
+   */
+  constructor(
+    public TS_TEST_CONTAINER: string = "awsosml/osml-tile-server-test:latest",
+    public TS_TEST_BUILD_PATH: string = "lib/osml-tile-server-test",
+    public TS_TEST_BUILD_TARGET: string = "osml_tile_server_test",
+    public TS_TEST_REPOSITORY: string = "tile-server-test-container"
+  ) {}
+}
+
+/**
+ * Interface representing the properties for the TSTestRunnerContainer construct.
+ */
+export interface TSTestRunnerContainerProps {
+  /**
+   * The OSML deployment account.
+   */
+  account: OSMLAccount;
+
+  /**
+   * The OSML vpc to deploy into
+   */
+  osmlVpc: OSMLVpc;
+
+  /**
+   * The DNS name of the Tile Server load balancer endpoint
+   */
+  tsEndpoint: string;
+
+  /**
+   * The S3 bucket name that contains test images for Tile Server
+   */
+  tsTestImageBucket: string;
+
+  /**
+   * Optional task role to be used by the TSTestContainer.
+   */
+  taskRole?: IRole;
+
+  /**
+   * Optional flag to instruct building tile server test container from source.
+   */
+  buildFromSource?: boolean;
+
+  /**
+   * Optional configuration for the TSTestContainer Construct
+   */
+  config?: TSTestRunnerContainerConfig;
+}
+
+/**
+ * Represents a construct responsible for deploying an ECR container image
+ * for the tile server test.
+ */
+export class TSTestRunnerContainer extends Construct {
+  public removalPolicy: RemovalPolicy;
+  public config: TSTestRunnerContainerConfig;
+  public dockerImageCode: DockerImageCode;
+  /**
+   * Creates an instance of TSTestRunnerContainer.
+   * @param {Construct} scope - The scope/stack in which to define this construct.
+   * @param {string} id - The id of this construct within the current scope.
+   * @param {TSTestRunnerContainerProps} props - The properties of this construct.
+   * @returns TSTestRunnerContainer - The TSTestRunnerContainer instance.
+   */
+  constructor(scope: Construct, id: string, props: TSTestRunnerContainerProps) {
+    super(scope, id);
+
+    // Set the removal policy based on the provided properties
+    this.removalPolicy = props.account.prodLike
+      ? RemovalPolicy.RETAIN
+      : RemovalPolicy.DESTROY;
+
+    // Check if a custom configuration was provided: otherwise, create a new default configuration.
+    if (props.config != undefined) {
+      // Import the existing TSTest configuration
+      this.config = props.config;
+    } else {
+      // Create a new default configuration
+      this.config = new TSTestRunnerContainerConfig();
+    }
+
+    let ecrDeployment: OSMLECRDeployment | undefined = undefined;
+    const testEntrypoint: string[] = [
+      "python",
+      "src/aws/osml/run_test.py",
+      "--endpoint",
+      props.tsEndpoint,
+      "--source_image_bucket",
+      props.tsTestImageBucket,
+      "-v"
+    ];
+
+    if (props.buildFromSource == true) {
+      // Create a container image from a Docker image asset for development environment.
+      this.dockerImageCode = DockerImageCode.fromImageAsset(
+        this.config.TS_TEST_BUILD_PATH,
+        {
+          file: "Dockerfile",
+          followSymlinks: SymlinkFollowMode.ALWAYS,
+          target: this.config.TS_TEST_BUILD_TARGET,
+          entrypoint: testEntrypoint
+        }
+      );
+    } else {
+      // Create an ECR deployment for production environment.
+      ecrDeployment = new OSMLECRDeployment(
+        this,
+        "TSTestContainerECRDeployment",
+        {
+          account: props.account,
+          sourceUri: this.config.TS_TEST_CONTAINER,
+          repositoryName: this.config.TS_TEST_REPOSITORY,
+          removalPolicy: this.removalPolicy,
+          vpc: props.osmlVpc.vpc,
+          vpcSubnets: props.osmlVpc.selectedSubnets
+        }
+      );
+      this.dockerImageCode = DockerImageCode.fromEcr(
+        ecrDeployment.ecrRepository,
+        {
+          entrypoint: testEntrypoint
+        }
+      );
+    }
+  }
+}

--- a/test/osml/tile_server/testing/ts_test_runner_container.test.ts
+++ b/test/osml/tile_server/testing/ts_test_runner_container.test.ts
@@ -8,7 +8,6 @@ import {
   OSMLVpc,
   TSImagery,
   TSImageryConfig,
-  TSTestRunner,
   TSTestRunnerContainer
 } from "../../../../lib";
 import { test_account } from "../../../test_account";
@@ -18,7 +17,6 @@ describe("TSDataplane constructor", () => {
   let stack: Stack;
   let osmlVpc: OSMLVpc;
   let tsTestRunnerContainer: TSTestRunnerContainer;
-  let tsTestRunner: TSTestRunner;
   let config: TSImageryConfig;
   let tsImagery: TSImagery;
 
@@ -51,19 +49,13 @@ describe("TSDataplane constructor", () => {
         buildFromSource: false
       }
     );
-
-    tsTestRunner = new TSTestRunner(stack, "TSDataplane", {
-      account: test_account,
-      osmlVpc: osmlVpc,
-      dockerImageCode: tsTestRunnerContainer.dockerImageCode
-    });
   });
 
   it("sets removal policy based on prodLike flag", () => {
     expect(tsImagery.removalPolicy).toEqual(RemovalPolicy.RETAIN);
   });
 
-  it("check of the ts integ runner is defined", () => {
-    expect(tsTestRunner.lambdaIntegRunner.functionArn).toBeDefined();
+  it("check of the ts test runner docker image code is defined", () => {
+    expect(tsTestRunnerContainer.dockerImageCode).toBeDefined();
   });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding dependency between tile server test lambda and ECR repo containing the pre-built image.  Previously lambda would fail because it was checking for the image before it had finished copying from dockerhub.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
