### PR TITLE
hotfix: update Bucket property to use autoDeleteObjects

### DIFF
--- a/lib/osml/osml_bucket.ts
+++ b/lib/osml/osml_bucket.ts
@@ -76,7 +76,7 @@ export class OSMLBucket extends Construct {
 
     // Set up shared properties for our bucket and access logging bucket
     const bucketProps = {
-      emptyOnDelete: !props.prodLike,
+      autoDeleteObjects: !props.prodLike,
       enforceSSL: true,
       encryption: BucketEncryption.KMS_MANAGED,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osml-cdk-constructs",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- `autoDeleteObjects` for S3 Bucket and `emptyOnDelete` for ECR Repo
  - emptyOnDelete does not exist for S3 Bucket according to the [aws-cdk package](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.Bucket.html#autodeleteobjects)

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
