### PR TITLE
chore: fixing depreciated CLOUDWATCH VPC endpoint setting

### DIFF
--- a/lib/osml/osml_vpc.ts
+++ b/lib/osml/osml_vpc.ts
@@ -171,7 +171,7 @@ export class OSMLVpc extends Construct {
           service: GatewayVpcEndpointAwsService.DYNAMODB
         });
         this.vpc.addInterfaceEndpoint("CWInterfaceEndpoint", {
-          service: InterfaceVpcEndpointAwsService.CLOUDWATCH,
+          service: InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING,
           privateDnsEnabled: true
         });
         this.vpc.addInterfaceEndpoint("CWLogsInterfaceEndpoint", {


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Seeing this - migrating

```
    /** @deprecated - Use InterfaceVpcEndpointAwsService.CLOUDWATCH_MONITORING instead. */
    static readonly CLOUDWATCH: InterfaceVpcEndpointAwsService;
```

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
