### PR TITLE
hotfix: add missing VPC permission for lambda and version bump

### DIFF
--- a/lib/osml/data_intake/roles/di_lambda_role.ts
+++ b/lib/osml/data_intake/roles/di_lambda_role.ts
@@ -82,6 +82,9 @@ export class DILambdaRole extends Construct {
       managedPolicies: [
         ManagedPolicy.fromAwsManagedPolicyName(
           "service-role/AWSLambdaBasicExecutionRole"
+        ),
+        ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaVPCAccessExecutionRole"
         )
       ]
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osml-cdk-constructs",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osml-cdk-constructs",
-      "version": "1.10.0",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
         "@cdklabs/cdk-enterprise-iac": "^0.0.450",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osml-cdk-constructs",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Add missing VPC permission for lambda role due to the following error caught during the deployment

```
"The provided execution role does not have permissions to call CreateNetworkInterface on EC2"
```
- Bump up the version to `v1.10.2`

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
