### PR TITLE
feat: add authorizer lambda and restapi construct

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,6 +30,8 @@ export * from "./osml/osml_topic";
 export * from "./osml/osml_vpc";
 export * from "./osml/osml_auth";
 export * from "./osml/osml_auth_alb";
+export * from "./osml/osml_authorizer/osml_authorizer";
+export * from "./osml/osml_restapi";
 export * from "./osml/data_catalog/dc_dataplane";
 export * from "./osml/data_catalog/dc_container";
 export * from "./osml/data_catalog/roles/dc_lambda_role";

--- a/lib/osml/data_catalog/Dockerfile
+++ b/lib/osml/data_catalog/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright 2024 Amazon.com, Inc. or its affiliates.
 
-FROM public.ecr.aws/lambda/python:3.10 as osml_data_catalog
+FROM public.ecr.aws/lambda/python:3.11 as osml_data_catalog
 
 RUN yum -y upgrade
 RUN yum -y install gcc

--- a/lib/osml/osml_authorizer/lambda/lambda_function.py
+++ b/lib/osml/osml_authorizer/lambda/lambda_function.py
@@ -1,0 +1,139 @@
+# Copyright 2024 Amazon.com, Inc. or its affiliates.
+
+import os
+import re
+import ssl
+from typing import Any, Dict, Union
+
+import jwt
+import requests
+
+def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
+    """
+    Handle authorization for REST API.
+
+    :param event: Lambda event
+    :param context: Lambda context
+
+    :return: IAM policy
+    """
+    print("REST API authorization handler started")
+
+    id_token = get_id_token(event)
+
+    print(id_token)
+
+    if not id_token:
+        print("Missing id_token in request. Denying access.")
+        print(f"REST API authorization handler completed with 'Deny' for resource {event['methodArn']}")
+        return generate_policy(effect="Deny", resource=event["methodArn"])
+
+    authority = os.environ.get("AUTHORITY", "")
+    client_id = os.environ.get("CLIENT_ID", "")
+
+    if jwt_data := id_token_is_valid(id_token=id_token, client_id=client_id, authority=authority):
+        policy = generate_policy(effect="Allow", resource=event["methodArn"], username=jwt_data["sub"])
+        policy["context"] = {"username": jwt_data["sub"]}
+
+        print(f"Generated policy: {policy}")
+        print("REST API authorization handler completed with 'Allow' for resource")
+        return policy
+
+    print("REST API authorization handler completed with 'Deny' for resource")
+    return generate_policy(effect="Deny", resource=event["methodArn"])
+
+
+def generate_policy(*, effect: str, resource: str, username: str = "username") -> Dict[str, Any]:
+    """
+    Generate IAM policy.
+
+    :param effect: Allow or Deny
+    :param resource: ARN of the resource
+    :param username: Username to add to the policy
+
+    :return: IAM policy
+    """
+    policy = {
+        "principalId": username,
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [{"Action": "execute-api:Invoke", "Effect": effect, "Resource": resource}],
+        },
+    }
+    return policy
+
+
+def id_token_is_valid(*, id_token: str, client_id: str, authority: str) -> Union[Dict[str, Any], bool]:
+    """
+    Check whether an ID token is valid and return decoded data.
+
+    :param id_token: ID token to validate
+    :param client_id: Client ID to validate against
+    :param authority: Authority to validate against
+
+    :return: Decoded JWT data or False if invalid
+    """
+    if not jwt.algorithms.has_crypto:
+        print("No crypto support for JWT, please install the cryptography dependency")
+        return False
+    print(f"{authority}/.well-known/openid-configuration")
+
+    # Here we will point to the sponsor bundle if available,
+    cert_path = os.getenv("SSL_CERT_FILE", None)
+    resp = requests.get(
+        f"{authority}/.well-known/openid-configuration",
+        verify=cert_path or True,
+        timeout=120,
+    )
+    if resp.status_code != 200:
+        print("Could not get OIDC metadata: %s", resp.content)
+        return False
+
+    oidc_metadata = resp.json()
+    try:
+        ctx = ssl.create_default_context()
+        if cert_path:
+            ctx.load_verify_locations(cert_path)
+        jwks_client = jwt.PyJWKClient(oidc_metadata["jwks_uri"], cache_jwk_set=True, lifespan=360, ssl_context=ctx)
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+        data: dict = jwt.decode(
+            id_token,
+            signing_key.key,
+            algorithms=["RS256"],
+            issuer=authority,
+            audience=client_id,
+            options={
+                "verify_signature": True,
+                "verify_exp": True,
+                "verify_nbf": True,
+                "verify_iat": True,
+                "verify_aud": True,
+                "verify_iss": True,
+            },
+        )
+        return data
+    except jwt.exceptions.PyJWTError as e:
+        print(e)
+        return False
+
+
+def get_id_token(event: dict) -> str:
+    """
+    Return token from event request headers.
+
+    :param event: lambda event
+    :return: Extracts bearer token from authorization header in lambda event.
+    """
+    # Normalize headers to lowercase
+    normalized_headers = { k.lower(): v for k, v in event["headers"].items() }
+
+    # Check for the authorization header in a case-insensitive way
+    pattern = r'(?:Bearer\s)?([A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+)'
+    if "authorization" in normalized_headers:
+        auth_token_match = re.match(pattern, normalized_headers["authorization"])
+        if auth_token_match:
+            return auth_token_match.group(1)
+        else:
+            raise ValueError("Invalid authorization header format.")
+    else:
+        raise ValueError("Missing authorization token.")

--- a/lib/osml/osml_authorizer/osml_authorizer.ts
+++ b/lib/osml/osml_authorizer/osml_authorizer.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates.
+ */
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+import { OSMLAccount } from "../osml_account";
+
+/**
+ * Represents the properties required to configure the OSMLAuthorizer Construct.
+ * @interface
+ */
+export interface OSMLAuthorizerProps {
+  /**
+   * The configuration for the authentication.
+   *
+   * @type {OSMLAuth}
+   */
+  account: OSMLAccount;
+
+  /**
+   * The name of the service
+   *
+   * @type {string}
+   */
+  name: string;
+}
+
+/**
+ * Represents the construct that creates Authorizer Lambda function
+ */
+export class OSMLAuthorizer extends Construct {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  public authorizerFunction: Function;
+
+  /**
+   * Creates an instance of OSMLAuthorizer Lambda Function
+   * @param {Construct} scope - The scope/stack in which to define this construct.
+   * @param {string} id - The unique id of the construct within current scope.
+   * @param {OSMLAuthorizerProps} props - The properties of this construct.
+   */
+  constructor(scope: Construct, id: string, props: OSMLAuthorizerProps) {
+    super(scope, id);
+
+    this.authorizerFunction = new Function(this, `AuthorizerFunction${id}`, {
+      functionName: `${props.name}-AuthorizerFunction`,
+      runtime: Runtime.PYTHON_3_11,
+      code: Code.fromAsset(
+        "lib/osml-cdk-constructs/lib/osml/osml_authorizer/lambda",
+        {
+          bundling: {
+            image: Runtime.PYTHON_3_11.bundlingImage,
+            command: [
+              "/bin/bash",
+              "-c",
+              "pip install pyjwt requests cryptography -t /asset-output && cp -au . /asset-output"
+            ]
+          }
+        }
+      ),
+      handler: "lambda_function.lambda_handler",
+      environment: {
+        AUTHORITY: props.account.auth ? props.account.auth.authority : "",
+        CLIENT_ID: props.account.auth ? props.account.auth.clientId : ""
+      }
+    });
+  }
+}

--- a/lib/osml/osml_restapi.ts
+++ b/lib/osml/osml_restapi.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Amazon.com, Inc. or its affiliates.
+ */
+import {
+  AuthorizationType,
+  IdentitySource,
+  Integration,
+  RequestAuthorizer,
+  RestApi
+} from "aws-cdk-lib/aws-apigateway";
+import { Construct } from "constructs";
+
+import { OSMLAccount } from "./osml_account";
+import { OSMLAuthorizer } from "./osml_authorizer/osml_authorizer";
+
+/**
+ * Represents the properties required to configure the OSMLRestApi Construct.
+ * @interface
+ */
+export interface OSMLRestApiProps {
+  /**
+   * The configuration for the authentication.
+   *
+   * @type {OSMLAuth}
+   */
+  account: OSMLAccount;
+
+  /**
+   * The name of the service
+   *
+   * @type {string}
+   */
+  name: string;
+
+  /**
+   * The name of the stage deployment for RestApi
+   *
+   * @type {string}
+   */
+  apiStageName: string;
+
+  /**
+   * The integration for the handler of the RestApi
+   *
+   * @type {Integration}
+   */
+  integration: Integration;
+}
+
+/**
+ * Represents the construct that attach authorizer to RestApi
+ */
+export class OSMLRestApi extends Construct {
+  public requestAuthorizer: RequestAuthorizer;
+  public restApi: RestApi;
+  public integration: Integration;
+
+  /**
+   * Creates an instance of OSML Rest APi
+   * @param {Construct} scope - The scope/stack in which to define this construct.
+   * @param {string} id - The unique id of the construct within current scope.
+   * @param {OSMLRestApiProps} props - The properties of this construct.
+   */
+  constructor(scope: Construct, id: string, props: OSMLRestApiProps) {
+    super(scope, id);
+
+    const osmlAuthorizer = new OSMLAuthorizer(this, `Authorizer${id}`, {
+      account: props.account,
+      name: props.name
+    });
+
+    this.requestAuthorizer = new RequestAuthorizer(
+      this,
+      `RequestAuthorizer${id}`,
+      {
+        authorizerName: `${props.name}-Authorizer`,
+        handler: osmlAuthorizer.authorizerFunction,
+        identitySources: [IdentitySource.header("Authorization")]
+      }
+    );
+
+    this.restApi = new RestApi(this, `RestApi${id}`, {
+      restApiName: `${props.name}-RestApi`,
+      deployOptions: {
+        stageName: props.apiStageName
+      },
+      defaultMethodOptions: {
+        authorizer: this.requestAuthorizer,
+        authorizationType: AuthorizationType.CUSTOM
+      }
+    });
+
+    this.restApi.root
+      .addResource("{proxy+}")
+      .addMethod("ANY", props.integration, {
+        authorizer: this.requestAuthorizer,
+        authorizationType: AuthorizationType.CUSTOM
+      });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "pre-commit run --all-files"
   },
   "devDependencies": {
-    "@cdklabs/cdk-enterprise-iac": "^0.0.450",
     "@aws-sdk/client-iam": "^3.592.0",
+    "@cdklabs/cdk-enterprise-iac": "^0.0.450",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/test/osml/data_catalog/dc_dataplane.test.ts
+++ b/test/osml/data_catalog/dc_dataplane.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { App, Stack } from "aws-cdk-lib";
-import { DockerImageCode } from "aws-cdk-lib/aws-lambda";
+import { Code, DockerImageCode } from "aws-cdk-lib/aws-lambda";
 import * as path from "path";
 
 import { DCDataplane, OSMLVpc } from "../../../lib";
@@ -31,6 +31,11 @@ describe("DCDataplane constructor", () => {
         path.join(__dirname, ""),
         { file: "Dockerfile" }
       );
+
+      Object.defineProperty(Code, "fromAsset", {
+        value: () => Code.fromInline("inline code")
+      });
+
       dcDataplane = new DCDataplane(stack, "DCDataplane", {
         account: test_account,
         lambdaRole: undefined,


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- Add Authorizer Lambda construct
- Integrate the Authorizer Lambda with APIGW in Data Catalog service
  - In order to use Data Catalog service, you must enable `Auth` in your `target_account.json`. We do not want to expose the APIGW publicly and freely accessible. 

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
