### PR TITLE
fix: removed unused model property and allow configuration of TS lambda asset

### DIFF
--- a/lib/osml/model_runner/monitoring/mr_monitoring.ts
+++ b/lib/osml/model_runner/monitoring/mr_monitoring.ts
@@ -72,13 +72,6 @@ export interface MRMonitoringProps {
    * @type {MRDataplaneConfig}
    */
   mrDataplaneConfig: MRDataplaneConfig;
-
-  /**
-   * Optional model information.
-   *
-   * @type {string | undefined}
-   */
-  model?: string;
 }
 
 /**
@@ -106,7 +99,7 @@ export class MRMonitoring extends Construct {
     const topRowWidgets = [
       new SingleValueWidget({
         region: props.account.region,
-        title: "Counts",
+        title: "Completed",
         width: 3,
         height: 5,
         metrics: [
@@ -121,7 +114,8 @@ export class MRMonitoring extends Construct {
               "SUM(SEARCH('{OSML/ModelRunner, ModelName, Operation} TileProcessing Invocations', 'Sum'))"
           })
         ],
-        sparkline: false
+        sparkline: false,
+        setPeriodToTimeRange: true
       }),
       new GraphWidget({
         region: props.account.region,
@@ -168,6 +162,7 @@ export class MRMonitoring extends Construct {
         width: 5,
         view: GraphWidgetView.PIE,
         statistic: "Average",
+        setPeriodToTimeRange: true,
         left: [
           new MathExpression({
             expression:
@@ -230,7 +225,7 @@ export class MRMonitoring extends Construct {
           "  fromMillis(request.start_time) as Start, fromMillis(request.end_time) as End",
           'filter message = "StatusMonitorUpdate" and status in ["SUCCESS", "FAILED"]',
           "sort @timestamp desc",
-          "limit 20"
+          "limit 50"
         ]
       })
     );

--- a/lib/osml/tile_server/ts_dataplane.ts
+++ b/lib/osml/tile_server/ts_dataplane.ts
@@ -147,6 +147,13 @@ export interface TSDataplaneProps {
   containerImage: ContainerImage;
 
   /**
+   * The location of the lambda function code to handle requests that end up in
+   *  the dead letter queue (DLQ).
+   * @type {string | undefined}
+   */
+  sourcePathDLQLambda?: string;
+
+  /**
    * Custom configuration for TSDataplane Constructs Authentication (optional)
    *  But it is required if setting enableAuth to true in your account configuration
    * @type {string[] | undefined}
@@ -239,7 +246,9 @@ export class TSDataplane extends Construct {
     // Create a Lambda function to clean up the TS DLQ
     this.lambdaSweeperFunction = new Function(this, "TSLambdaSweeperDLQ", {
       code: Code.fromAsset(
-        "lib/osml-tile-server/src/aws/osml/tile_server/lambda"
+        props.sourcePathDLQLambda
+          ? props.sourcePathDLQLambda
+          : "lib/osml-tile-server/src/aws/osml/tile_server/lambda"
       ),
       handler: "cleanup_dlq.lambda_handler",
       functionName: "TSLambdaSweeperDLQ",

--- a/test/osml/model_runner/monitoring/mr_monitoring.test.ts
+++ b/test/osml/model_runner/monitoring/mr_monitoring.test.ts
@@ -49,8 +49,7 @@ describe("OSMLMonitoring constructor", () => {
         imageRequestDlQueue: mrDataplane.imageRequestQueue.dlQueue,
         regionRequestDlQueue: mrDataplane.regionRequestQueue.dlQueue,
         service: mrDataplane.fargateService,
-        mrDataplaneConfig: mrDataplane.mrDataplaneConfig,
-        model: "aircraft"
+        mrDataplaneConfig: mrDataplane.mrDataplaneConfig
       });
     });
 


### PR DESCRIPTION
These changes are minor updates to support expanded examples in the guidance repository. Updates include:
- The unused "model" configuration option has been removed from from the ModelRunner monitoring stack.
- The dashboard has been updated to align with the documented examples in the ModelRunner repository.
- The TileServer construct has been updated to allow configuration of the source path for the DLQ lambda. 


### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
