### PR TITLE
fix: update maxAzs vpc prop

### DIFF
--- a/lib/osml/data_catalog/dc_dataplane.ts
+++ b/lib/osml/data_catalog/dc_dataplane.ts
@@ -40,7 +40,6 @@ export class DCDataplaneConfig {
    * @param {number} LAMBDA_TIMEOUT The timeout of the Lambda function.
    * @param {number} OS_DATA_NODES The number of data nodes in the OpenSearch cluster.
    * @param {number} OS_EBS_SIZE The EBS size of the OpenSearch cluster.
-   * @param {number} AZ_ZONES The number of availability zones for the data catalog server.
    * @param {string} STAC_FASTAPI_TITLE The title of the STAC FastAPI application.
    * @param {string} STAC_FASTAPI_DESCRIPTION The description of the STAC FastAPI application.
    * @param {string} STAC_FASTAPI_VERSION The version of the STAC FastAPI application.
@@ -60,7 +59,6 @@ export class DCDataplaneConfig {
     public LAMBDA_TIMEOUT: number = 300, // 5 minutes
     public OS_DATA_NODES: number = 4,
     public OS_EBS_SIZE: number = 10,
-    public AZ_ZONES: number = 3,
     public STAC_FASTAPI_TITLE: string = "stac-fastapi-opensearch",
     public STAC_FASTAPI_DESCRIPTION: string = "A STAC FastAPI with an OpenSearch backend",
     public STAC_FASTAPI_VERSION: string = "2.4.1",
@@ -186,7 +184,7 @@ export class DCDataplane extends Construct {
         : RemovalPolicy.DESTROY,
       zoneAwareness: {
         enabled: true,
-        availabilityZoneCount: this.config.AZ_ZONES
+        availabilityZoneCount: props.osmlVpc.selectedSubnets.subnetIds.length
       },
       securityGroups: [opensearchSecurityGroup]
     });

--- a/test/osml/data_catalog/dc_dataplane.test.ts
+++ b/test/osml/data_catalog/dc_dataplane.test.ts
@@ -20,11 +20,8 @@ describe("DCDataplane constructor", () => {
       app = new App();
       stack = new Stack(app, "DCDataplaneStack");
 
-      const availabilityZones = ["us-west-2a", "us-west-2b", "us-west-2c"];
-
       osmlVpc = new OSMLVpc(stack, "OSMLVpc", {
-        account: test_account,
-        availabilityZones: availabilityZones
+        account: test_account
       });
 
       const dockerImageCode = DockerImageCode.fromImageAsset(


### PR DESCRIPTION
**Issue #, if available:** 
### Notes

This PR resolves the issue of deploying the VPC stack into a non-ISO AWS region with less than 3 AZs. 
```
Template error: Fn::Select cannot select nonexistent value at index 2
```

The `Fn::GetAzs` CFN function was returning more AZs than the VPC could create subnets in. Specifically, in us-west-1.

Providing the customer with the option to specify the number of AZs they want to use, otherwise default to 2.

I also updated the DCDataplane Domain to use the same number of AZs as the VPC rather than an arbitrary config value.


### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
