### PR TITLE
fix: add maxAzs config

### DIFF
--- a/lib/osml/osml_vpc.ts
+++ b/lib/osml/osml_vpc.ts
@@ -2,7 +2,7 @@
  * Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
  */
 
-import { RemovalPolicy, Stack } from "aws-cdk-lib";
+import { RemovalPolicy } from "aws-cdk-lib";
 import {
   FlowLog,
   FlowLogDestination,
@@ -20,6 +20,7 @@ import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 
 import { OSMLAccount } from "./osml_account";
+import { maxAzsConfig } from "./utils/region_az_config";
 
 /**
  * Configuration properties for the OSMLVpc Construct, defining how the VPC should be setup.
@@ -113,9 +114,7 @@ export class OSMLVpc extends Construct {
     } else {
       const vpc = new Vpc(this, "OSMLVPC", {
         vpcName: props.vpcName,
-        // Default two AZs, customer can use more if they'd like
-        maxAzs:
-          props.maxAzs ?? Math.min(2, Stack.of(this).availabilityZones.length),
+        maxAzs: props.maxAzs ?? maxAzsConfig[props.account.region],
         subnetConfiguration: [
           {
             cidrMask: 23,

--- a/lib/osml/utils/region_az_config.ts
+++ b/lib/osml/utils/region_az_config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+ */
+export const maxAzsConfig: { [key: string]: number } = {
+  "ap-south-1": 3,
+  "eu-north-1": 3,
+  "eu-west-3": 3,
+  "eu-west-2": 3,
+  "eu-west-1": 3,
+  "ap-northeast-3": 3,
+  "ap-northeast-2": 3,
+  "ap-northeast-1": 3,
+  "ca-central-1": 3,
+  "sa-east-1": 3,
+  "ap-southeast-1": 3,
+  "ap-southeast-2": 3,
+  "eu-central-1": 3,
+  "us-east-1": 3,
+  "us-east-2": 3,
+  "us-west-1": 2,
+  "us-west-2": 3,
+  "us-gov-east-1": 3,
+  "us-gov-west-1": 3,
+  "us-isob-east-1": 2,
+  "us-iso-east-1": 3,
+  "us-iso-west-1": 3
+};


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes

Maintaining a static config of the default VPC AZs deployed in each region. This prevents us from breaking existing customers if they already have a VPC deployed with more than 2 AZs. Customers have the option to change this property by setting `maxAzs` if they want.


### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
