### PR TITLE
fix: increasing lambda timeouts for data intake

### DIFF
--- a/lib/osml/data_intake/di_dataplane.ts
+++ b/lib/osml/data_intake/di_dataplane.ts
@@ -39,7 +39,7 @@ export class DIDataplaneConfig {
     public LAMBDA_MEMORY_SIZE: number = 1024,
     public LAMBDA_RETRY_ATTEMPTS: number = 3,
     public LAMBDA_STORAGE_SIZE: number = 10,
-    public LAMBDA_TIMEOUT: number = 120,
+    public LAMBDA_TIMEOUT: number = 900,
     public SNS_INPUT_TOPIC_NAME: string = "osml-data-intake",
     public SNS_STAC_TOPIC_NAME: string = "osml-stac-ingest",
     public S3_INPUT_BUCKET_NAME: string = "di-input-bucket",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Increasing data intake lambda timeouts to 15 minutes to handle the largest / longest running images possible.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
