### PR TITLE
chore: fixing container repo link to data intake container

### DIFF
--- a/lib/osml/data_intake/di_container.ts
+++ b/lib/osml/data_intake/di_container.ts
@@ -23,7 +23,7 @@ export class DIContainerConfig {
    * @param {string} [DI_REPOSITORY="data-intake-container"] - The repository name for the Data Intake source repo.
    */
   constructor(
-    public DI_CONTAINER: string = "awsosml/osml-data-intake:latest",
+    public DI_CONTAINER: string = "awsosml/osml-data-intake-intake:latest",
     public DI_BUILD_PATH: string = "lib/osml-data-intake",
     public DI_BUILD_TARGET: string = "intake",
     public DI_DOCKERFILE: string = "docker/Dockerfile.intake",


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Fixing container repo link to data intake container to correctly point at the published [repository](https://hub.docker.com/repository/docker/awsosml/osml-data-intake-intake/general)

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
