### PR TITLE
fix: adding leading / to fastapi path to delimit domain

### DIFF
--- a/lib/osml/data_catalog/dc_dataplane.ts
+++ b/lib/osml/data_catalog/dc_dataplane.ts
@@ -202,7 +202,7 @@ export class DCDataplane extends Construct {
       ES_PORT: this.config.ES_PORT,
       ES_USE_SSL: this.config.ES_USE_SSL,
       ES_VERIFY_CERTS: this.config.ES_VERIFY_CERTS,
-      STAC_FASTAPI_ROOT_PATH: this.config.STAC_FASTAPI_ROOT_PATH
+      STAC_FASTAPI_ROOT_PATH: `/${this.config.STAC_FASTAPI_ROOT_PATH}`
     };
 
     // Package op the container function


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
Restoring the leading `/` to the data catalog's `STAC_FASTAPI_ROOT_PATH`.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
