### PR TITLE
fix: add DeleteItem permission to TSTaskPolicy

### DIFF
--- a/lib/osml/tile_server/roles/ts_task_role.ts
+++ b/lib/osml/tile_server/roles/ts_task_role.ts
@@ -92,6 +92,7 @@ export class TSTaskRole extends Construct {
         "dynamodb:*GetItem",
         "dynamodb:*PutItem",
         "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
         "dynamodb:DescribeTable"
       ],
       resources: [


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This PR adds the DeleteItem permission to the Tile Server Task Policy to allow the TS router to delete viewpoints.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
