### PR TITLE
fix: updating DI and DC ingest topic names to be unique

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,13 @@ jobs:
         run: |
           npm ci
           npm run build --if-present
-      - uses: pre-commit/action@v3.0.0
+      - name: Install Pre-commit
+        run: |
+          pip install pre-commit
+      - name: Run Pre-commit for Changed Files
+        run: |
+          git fetch origin main
+          git diff --name-only origin/main...HEAD | xargs pre-commit run --files
       - uses: ArtiomTr/jest-coverage-report-action@v2.3.0
         with:
           annotations: failed-tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -22,7 +22,7 @@ repos:
         types: [ file ]
 
   - repo: https://github.com/aws-samples/automated-security-helper
-    rev: '1.0.9-e-16May2023' # update with the latest-tagged version in the repository
+    rev: 'v2.0.1' # update with the latest-tagged version in the repository
     hooks:
       - id: ash
         stages: [ manual ]
@@ -30,7 +30,7 @@ repos:
         # args: [ "-f" ]
 
   - repo: https://github.com/sbrunner/pre-commit-copyright
-    rev: 0.7.0
+    rev: 1.2.1
     hooks:
       - id: copyright
         name: update copyright

--- a/lib/osml/data_catalog/dc_dataplane.ts
+++ b/lib/osml/data_catalog/dc_dataplane.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Amazon.com, Inc. or its affiliates.
+ * Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
  */
 
 import { Duration, RemovalPolicy, Size } from "aws-cdk-lib";
@@ -200,7 +200,7 @@ export class DCDataplaneConfig extends BaseConfig {
       LAMBDA_STORAGE_SIZE: 10,
       LAMBDA_TIMEOUT: 300,
       OS_DATA_NODES: 4,
-      SNS_INGEST_TOPIC_NAME: "osml-stac-ingest",
+      SNS_INGEST_TOPIC_NAME: "osml-dc-ingest",
       STAC_CONTAINER_DOCKERFILE: "docker/Dockerfile.stac",
       STAC_CONTAINER_BUILD_TARGET: "stac",
       STAC_CONTAINER_URI: "awsosml/osml-data-intake-stac:latest",

--- a/lib/osml/data_intake/di_dataplane.ts
+++ b/lib/osml/data_intake/di_dataplane.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+ * Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
  */
 
 import { Duration, RemovalPolicy, Size } from "aws-cdk-lib";
@@ -123,7 +123,7 @@ export class DIDataplaneConfig extends BaseConfig {
       LAMBDA_TIMEOUT: 900,
       S3_OUTPUT_BUCKET_NAME: "di-output-bucket",
       SNS_INPUT_TOPIC_NAME: "osml-data-intake",
-      SNS_STAC_TOPIC_NAME: "osml-stac-ingest",
+      SNS_STAC_TOPIC_NAME: "osml-di-ingest",
       ...config
     });
   }


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
* Modifies the ingest topic names in the DI and DC constructs to ensure they are unique. The change prevents resource collisions when both constructs are integrated directly within the same CDK project. Unique topic names eliminate naming conflicts, ensuring reliable deployment of both DI and DC constructs and supports scenarios where DI and DC are deployed independently into the same account.

* Updates the Github actions to use latest versions to resolve warnings showed as part of this build.

* Pre-commit logic has been updated to avoid breaks at the turn of the new year to explicit run pre-commit against files that changed as part of each commit.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
