### PR TITLE
fix: correctly parse ECR URIs and tags to OSMLContainer

### DIFF
--- a/lib/osml/model_endpoint/me_http_endpoint.ts
+++ b/lib/osml/model_endpoint/me_http_endpoint.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+ * Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
  */
 
 import { Duration, RemovalPolicy } from "aws-cdk-lib";
@@ -8,6 +8,7 @@ import {
   Cluster,
   Compatibility,
   ContainerImage,
+  ContainerInsights,
   LogDriver,
   Protocol,
   TaskDefinition
@@ -168,7 +169,9 @@ export class MEHTTPEndpoint extends Construct {
     const httpEndpointCluster = new Cluster(this, props.clusterName, {
       clusterName: props.clusterName,
       vpc: props.osmlVpc.vpc,
-      containerInsights: props.account.prodLike
+      containerInsightsV2: props.account.prodLike
+        ? ContainerInsights.ENABLED
+        : ContainerInsights.DISABLED
     });
 
     // Determine the removal policy based on the environment

--- a/lib/osml/model_runner/mr_dataplane.ts
+++ b/lib/osml/model_runner/mr_dataplane.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+ * Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
  */
 
 import { EcsIsoServiceAutoscaler } from "@cdklabs/cdk-enterprise-iac";
@@ -18,6 +18,7 @@ import {
   Cluster,
   Compatibility,
   ContainerDefinition,
+  ContainerInsights,
   FargateService,
   Protocol,
   TaskDefinition
@@ -662,7 +663,9 @@ export class MRDataplane extends Construct {
     this.cluster = new Cluster(this, "MRCluster", {
       clusterName: this.config.ECS_CLUSTER_NAME,
       vpc: props.osmlVpc.vpc,
-      containerInsights: props.account.prodLike
+      containerInsightsV2: props.account.prodLike
+        ? ContainerInsights.ENABLED
+        : ContainerInsights.DISABLED
     });
 
     // Define our ECS task

--- a/test/osml/osml_container.test.ts
+++ b/test/osml/osml_container.test.ts
@@ -1,43 +1,147 @@
 /*
- * Copyright 2024 Amazon.com, Inc. or its affiliates.
+ * Copyright 2024-2025 Amazon.com, Inc. or its affiliates.
  */
 
-import { App, Stack } from "aws-cdk-lib";
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 
 import { OSMLContainer } from "../../lib";
 import { test_account } from "../test_account";
 
-describe("MEContainer", () => {
+jest.mock("aws-cdk-lib/aws-ecr-assets", () => {
+  return {
+    DockerImageAsset: jest.fn().mockImplementation(() => ({
+      imageUri: "mock-image-uri"
+    }))
+  };
+});
+
+describe("OSMLContainer", () => {
   let app: App;
   let stack: Stack;
-  let container: OSMLContainer;
 
   beforeEach(() => {
     app = new App();
-    stack = new Stack(app, "MEContainerStack");
+    stack = new Stack(app, "OSMLContainerStack");
+  });
 
-    // Mock dependencies
-    container = new OSMLContainer(stack, "OSMLContainer", {
+  it("sets correct removal policy based on environment", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
       account: test_account,
-      buildDockerImageCode: true,
-      buildFromSource: false,
+      config: { CONTAINER_URI: "awsosml/test-uri" }
+    });
+
+    expect(container.removalPolicy).toBe(
+      test_account.prodLike ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY
+    );
+  });
+
+  it("throws an error if neither ECR_REPOSITORY_ARN nor CONTAINER_URI is provided", () => {
+    expect(() => {
+      new OSMLContainer(stack, "OSMLContainer", {
+        account: test_account
+      });
+    }).toThrow(
+      "Either CONTAINER_URI or ECR_REPOSITORY_ARN must be set in the configuration."
+    );
+  });
+
+  it("throws error when both CONTAINER_URI and REPOSITORY_ARN are set", () => {
+    expect(() => {
+      new OSMLContainer(stack, "OSMLContainer", {
+        account: test_account,
+        config: {
+          CONTAINER_URI: "awsosml/test-uri",
+          ECR_REPOSITORY_ARN:
+            "arn:aws:ecr:us-east-1:123456789012:repository/my-repo"
+        }
+      });
+    }).toThrow("Only one of CONTAINER_URI or ECR_REPOSITORY_ARN can be set.");
+  });
+
+  it("uses container image from CONTAINER_URI", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
+      config: { CONTAINER_URI: "awsosml/test-uri:latest" }
+    });
+
+    expect(container.containerImage).toBeDefined();
+    expect(container.containerUri).toBe("awsosml/test-uri:latest");
+  });
+
+  it("uses container image from REPOSITORY_ARN", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
       config: {
-        CONTAINER_URI: "awsosml/test-uri"
+        ECR_REPOSITORY_ARN:
+          "arn:aws:ecr:us-east-1:123456789012:repository/my-repo"
       }
     });
-  });
 
-  it("sets removal policy", () => {
-    expect(container.removalPolicy).toBeDefined();
-  });
-
-  it("creates config if not provided", () => {
-    expect(container.config).toBeDefined();
-  });
-
-  it("sets container image", () => {
+    expect(container.repository).toBeDefined();
     expect(container.containerImage).toBeDefined();
-    expect(container.config).toBeDefined();
-    expect(container.dockerImageCode).toBeDefined();
+    expect(container.containerUri).toContain("123456789012.dkr.ecr.us-east-1");
+    expect(container.containerUri).toContain("/my-repo");
+  });
+
+  it("builds Docker image when buildFromSource is enabled", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
+      buildFromSource: true,
+      config: {
+        CONTAINER_DOCKERFILE: "Dockerfile",
+        CONTAINER_BUILD_PATH: "./path/to/build"
+      }
+    });
+
+    expect(container.dockerImageAsset).toBeDefined();
+    expect(container.containerImage).toBeDefined();
+    expect(container.containerUri).toBe(container.dockerImageAsset.imageUri);
+  });
+
+  it("throws error when buildFromSource is enabled but missing required fields", () => {
+    expect(() => {
+      new OSMLContainer(stack, "OSMLContainer", {
+        account: test_account,
+        buildFromSource: true,
+        config: {}
+      });
+    }).toThrow(
+      "CONTAINER_DOCKERFILE and CONTAINER_BUILD_PATH must be set in the configuration to build from source."
+    );
+  });
+
+  it("uses external registry image when given a non-ECR URI", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
+      config: { CONTAINER_URI: "docker.io/library/nginx:1.21" }
+    });
+
+    expect(container.containerImage).toBeInstanceOf(ContainerImage);
+    expect(container.containerUri).toBe("docker.io/library/nginx:1.21");
+  });
+
+  it("creates Docker image code for Lambda when enabled", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
+      buildFromSource: true,
+      buildDockerImageCode: true,
+      config: {
+        CONTAINER_DOCKERFILE: "Dockerfile",
+        CONTAINER_BUILD_PATH: "./path/to/build"
+      }
+    });
+
+    expect(container.dockerImageCode).toBeInstanceOf(Object);
+  });
+
+  it("does not create Docker image code when buildDockerImageCode is false", () => {
+    const container = new OSMLContainer(stack, "OSMLContainer", {
+      account: test_account,
+      buildDockerImageCode: false,
+      config: { CONTAINER_URI: "awsosml/test-uri:latest" }
+    });
+
+    expect(container.dockerImageCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
#### Fix: Correctly Support ECR Repository ARN and CONTAINER_URI tags as OSMLContainer configuration options.

This PR enhances the `buildFromRepository()` method by **adding support for importing ECR repositories via ARN (`REPOSITORY_ARN`)** and **improving the extraction and handling of container image URIs**. Previously, the code:
- **Did not support repository ARNs**, requiring only `CONTAINER_URI`.
- **Incorrectly checked for an ECR ARN instead of an ECR URI**.
- **Defaulted to `"latest"` even when a tag was present** in the `CONTAINER_URI`.

## Changes
- **Adds support for `REPOSITORY_ARN`**, allowing users to provide an **ECR repository ARN** instead of a full image URI.
- **Ensures only one of `CONTAINER_URI` or `REPOSITORY_ARN` is provided**, preventing misconfigurations.
- **Extracts and respects image tags** from `CONTAINER_URI` (e.g., `repo-name:tag`).
- **Fixes ECR repository detection** by properly recognizing **ECR URIs and ARNs**.
- **Ensures compatibility** with both **ECR repositories and external registries (Docker Hub, private registries, etc.)**.
- **Refactors `buildFromRepository()` into multiple helper methods** for better readability and maintainability.
- **Improved Testing** added for entire ``OSMLContainer`` construct including new options.
- **Depreciated Inputs** have been updated in a few places to remove warnings from builds.

## Example Fixes
| **Before (Bugged)** | **After (Fixed)** |
|-----------------|----------------|
| No support for **ECR repository ARNs** (`REPOSITORY_ARN` was not accepted) | Supports importing a full ECR repository via `REPOSITORY_ARN` |
| `123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:1.2.3` was incorrectly assumed to be **Docker Hub** (`docker.io/library/...`) | Correctly recognized as an **ECR image**, using the **"1.2.3"** tag |
| If a tag was provided in `CONTAINER_URI`, it was ignored and `"latest"` was always used | The **provided tag** is now respected |
| An **ECR ARN** was required instead of a **URI**, causing failures | Now properly supports **ECR repository ARNs and URIs** |

## Impact
- **Supports importing full ECR repositories using `REPOSITORY_ARN`**.
- **Fixes CannotPullContainerError** for ECS tasks pulling images from ECR.
- **Prevents accidental usage of `:latest`** when an explicit tag is provided.
- **Improves compatibility** with AWS best practices for ECR repositories.
- **Enhances maintainability** with a modularized implementation.

This update ensures that users can **seamlessly use either an ECR repository ARN or a container image URI**, improving flexibility and correctness. 🚀

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
