### PR TITLE
feat: add MROutstandingImageJobsTable to MRDataplane

### DIFF
--- a/test/osml/model_runner/mr_dataplane.test.ts
+++ b/test/osml/model_runner/mr_dataplane.test.ts
@@ -37,6 +37,7 @@ describe("MRDataplane constructor", () => {
       expect(mrDataplane.removalPolicy).toBeDefined();
       expect(mrDataplane.featureTable).toBeDefined();
       expect(mrDataplane.jobStatusTable).toBeDefined();
+      expect(mrDataplane.outstandingImageJobsTable).toBeDefined();
       expect(mrDataplane.regionRequestTable).toBeDefined();
       expect(mrDataplane.endpointStatisticsTable).toBeDefined();
       expect(mrDataplane.imageRequestQueue).toBeDefined();


### PR DESCRIPTION
This change adds a new DynamoDB table to the ModelRunner dataplane construct. This new table is for use by future job scheduler implementations that need to keep a record of requests pulled from the SQS queue that have not yet been started. Changes include creation of the table and passing of the table's name into the ModelRunner application via a environment variable in the ECS task configuration.

Unit tests were updated and changes were manually verified by deploying a new stack and confirming that the table and environment were updated as expected.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
